### PR TITLE
EXT pins as GPIOs

### DIFF
--- a/webgui/js_new/communication/ATDevice.js
+++ b/webgui/js_new/communication/ATDevice.js
@@ -121,12 +121,19 @@ ATDevice.init = function (dontGetLiveValues) {
         } else {
             _sensorInfo[C.PRESSURE_SENSOR]=true;
             console.log("Pressure Sensor found");
+            //save the detected sensor
+            if (versionString.indexOf(C.PRESSURE_SENSOR_TYPE_ADC)>0) { _sensorInfo[C.PRESSURE_SENSOR_TYPE_ADC] = true; }
+            if (versionString.indexOf(C.PRESSURE_SENSOR_TYPE_DPS310)>0) { _sensorInfo[C.PRESSURE_SENSOR_TYPE_DPS310] = true; }
+            if (versionString.indexOf(C.PRESSURE_SENSOR_TYPE_MPRLS)>0) { _sensorInfo[C.PRESSURE_SENSOR_TYPE_MPRLS] = true; }
         }
         _sensorInfo[C.FORCE_SENSOR]=false;
         if ((versionString.indexOf(C.FORCE_SENSOR_TYPE_NAU7802)>0) ||
             (versionString.indexOf(C.FORCE_SENSOR_TYPE_ADC)>0)) {
             _sensorInfo[C.FORCE_SENSOR]=true;
             console.log("Force Sensor found");
+            //save the detected sensor
+            if (versionString.indexOf(C.FORCE_SENSOR_TYPE_ADC)>0) { _sensorInfo[C.FORCE_SENSOR_TYPE_ADC] = true; }
+            if (versionString.indexOf(C.FORCE_SENSOR_TYPE_NAU7802)>0) { _sensorInfo[C.FORCE_SENSOR_TYPE_NAU7802] = true; }
         } else {
             console.log("No Force Sensor available");
         }

--- a/webgui/js_new/constantsGeneric.js
+++ b/webgui/js_new/constantsGeneric.js
@@ -5,6 +5,7 @@ import { TabGeneral } from "./ui/views/TabGeneral.js";
 import { TabTimings } from "./ui/views/TabTimings.js";
 import { TabSipPuff } from "./ui/views/TabSipPuff.js";
 import { TabVisualization } from "./ui/views/TabVisualization.js";
+import { ATDevice } from "./communication/ATDevice.js";
 
 window.C = window.C || {};
 
@@ -160,6 +161,19 @@ export function getBtnModesActionList() {
             list.push({
                 index: currentIndex++,
                 label: `Button ${i}`,
+                category: C.BTN_CAT_BTN
+            });
+        }
+        // analog joystick, no pressure sensor (use I2C as GPIO, 2 extra buttons mapped to sip/puff)
+        if(ATDevice.getSensorInfo()[C.FORCE_SENSOR_TYPE_ADC] && !ATDevice.getSensorInfo()[C.PRESSURE_SENSOR]) {
+            list.push({
+                index: 10,
+                label: `Button left // Button links`,
+                category: C.BTN_CAT_BTN
+            });
+            list.push({
+                index: 12,
+                label: `Button right // Button rechts`,
                 category: C.BTN_CAT_BTN
             });
         }

--- a/webgui/js_new/ui/views/TabVisualization.js
+++ b/webgui/js_new/ui/views/TabVisualization.js
@@ -15,9 +15,14 @@ class TabVisualization extends Component {
         // Dynamically initialize the first C.PHYSICAL_BUTTON_COUNT elements
         const physicalButtonCount = C.PHYSICAL_BUTTON_COUNT; 
         const physicalButtonNames = Array.from({ length: physicalButtonCount }, (_, i) => `${i + 1}`);
+        let additionalButtonNames;
 
-        // Add the remaining button (virtual button function) names
-        const additionalButtonNames = ["Up // Rauf", "Down // Runter", "Left // Links", "Right // Rechts", "Sip // Ansaugen", "Strong Sip // Starkes Ansaugen", "Puff // Pusten", "Strong Puff // Starkes Pusten"];
+        // Add the remaining button (virtual button function) names; re-use sip/puff as 6.&7. button when using SDA/SCL as GPIOs.
+        if(ATDevice.getSensorInfo()[C.FORCE_SENSOR_TYPE_ADC] && !ATDevice.getSensorInfo()[C.PRESSURE_SENSOR]) {
+            additionalButtonNames = ["Up // Rauf", "Down // Runter", "Left // Links", "Right // Rechts", "Btn-L // Btn Links", "Strong Sip // Starkes Ansaugen", "Btn-R // Btn Rechts", "Strong Puff // Starkes Pusten"];
+        } else {
+            additionalButtonNames = ["Up // Rauf", "Down // Runter", "Left // Links", "Right // Rechts", "Sip // Ansaugen", "Strong Sip // Starkes Ansaugen", "Puff // Pusten", "Strong Puff // Starkes Pusten"];
+        }
         TabVisualization.BTN_NAMES = [...physicalButtonNames, ...additionalButtonNames];
 
         this.setState({
@@ -48,9 +53,16 @@ class TabVisualization extends Component {
             if ((!ATDevice.getSensorInfo()[C.FORCE_SENSOR]) && (index >= C.PHYSICAL_BUTTON_COUNT && index < C.PHYSICAL_BUTTON_COUNT+4)) {  // up, down, left, right buttons (functions)
                 return '';
             }
-            if ((!ATDevice.getSensorInfo()[C.PRESSURE_SENSOR]) && (index >= C.PHYSICAL_BUTTON_COUNT+4)) {  // sip and puff buttons (functions)
-                return '';
+
+            if(ATDevice.getSensorInfo()[C.FORCE_SENSOR_TYPE_ADC] && !ATDevice.getSensorInfo()[C.PRESSURE_SENSOR] && (index >= C.PHYSICAL_BUTTON_COUNT+4)) {
+                //show sip/puff as buttons; but others not
+                if(index != C.PHYSICAL_BUTTON_COUNT+4 && index != C.PHYSICAL_BUTTON_COUNT+6) return '';
+            } else {
+                if ((!ATDevice.getSensorInfo()[C.PRESSURE_SENSOR]) && (index >= C.PHYSICAL_BUTTON_COUNT+4)) {  // sip and puff buttons (functions)
+                    return '';
+                }
             }
+            
 
             let color = buttonState ? 'orange' : 'transparent';
             return html`<div style="margin: 10px; ${styleUtil.getCircleStyle(circleRadius, color, 'medium solid')}; ${fontStyle}">${L.translate(btnNames[index])}</div>`


### PR DESCRIPTION
This PR adds the possibility to re-use the SDA/SCL lines on the EXT header to be displayed and configured in the WebGUI.

Full disclosure: because it would be an overkill to extend the firmware to 7 physical buttons just for this usecase, I reused the sip & puff actions. Simply because it's mutual exclusive on the FABI to use the I2C pressure sensor and use SDA/SCL as GPIOs the same time.

In future situation when we can define actions better, this workaround can be removed.

Changes:
* added exact pressure & force sensor to _sensorInfo. e.g. test if the device is using the internal ADC: `if(ATDevice.getSensorInfo()[C.FORCE_SENSOR_TYPE_ADC])`
* `additionalButtonNames` will be built either with "Sip/Puff" or "Button Left/ Button Right" (Visualization)
* `getBtnModesActionList()` added AT BM 10 & AT BM 12 to the button category